### PR TITLE
Bump rexml from 3.3.3 to 3.3.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,7 +88,7 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rexml (3.3.3)
+    rexml (3.3.6)
       strscan
     rouge (4.3.0)
     rubyzip (2.3.2)


### PR DESCRIPTION
### Description

The changes in this pull request consist of updating the version of the "rexml" gem in the Gemfile.lock from 3.3.3 to 3.3.6.

- Update the version of the "rexml" gem from 3.3.3 to 3.3.6 in Gemfile.lock.

These changes update the version of the "rexml" gem in the project's Gemfile.lock.